### PR TITLE
Pullup ticket #6597 - requested by bouyer

### DIFF
--- a/sysutils/xenkernel415/Makefile
+++ b/sysutils/xenkernel415/Makefile
@@ -1,6 +1,6 @@
-# $NetBSD: Makefile,v 1.3 2021/09/21 12:23:49 bouyer Exp $
+# $NetBSD: Makefile,v 1.3.4.1 2022/03/24 18:59:43 bsiegert Exp $
 
-VERSION=	4.15.1
+VERSION=	4.15.2
 DISTNAME=	xen-${VERSION}
 PKGNAME=	xenkernel415-${VERSION}
 CATEGORIES=	sysutils

--- a/sysutils/xenkernel415/distinfo
+++ b/sysutils/xenkernel415/distinfo
@@ -1,14 +1,14 @@
-$NetBSD: distinfo,v 1.4 2021/10/26 11:20:25 nia Exp $
+$NetBSD: distinfo,v 1.4.2.1 2022/03/24 18:59:43 bsiegert Exp $
 
-BLAKE2s (xen415/xen-4.15.1.tar.gz) = 87499f2cbe2a81fd92e0d4803adbe8681b9a26348aa8e069890b6ea441731986
-SHA512 (xen415/xen-4.15.1.tar.gz) = 8d3cbdf708f46477e32ee7cbd16a490c82efa855cecd84ee712b8680df4d69c987ba9ab00ff3851f627b98a8ebbc5dab71f92f142ed958ee2bc538bc792cd4b9
-Size (xen415/xen-4.15.1.tar.gz) = 40800852 bytes
+BLAKE2s (xen415/xen-4.15.2.tar.gz) = f6e3d354a144c9ff49a198ebcafbd5e8a4414690d5672b3e2ed394c461ab8ab0
+SHA512 (xen415/xen-4.15.2.tar.gz) = 1cbf988fa8ed38b7ad724978958092ca0e5506e38c709c7d1af196fb8cb8ec0197a79867782761ef230b268624b3d7a0d5d0cd186f37d25f495085c71bf70d54
+Size (xen415/xen-4.15.2.tar.gz) = 40773378 bytes
 SHA1 (patch-Config.mk) = 9372a09efd05c9fbdbc06f8121e411fcb7c7ba65
 SHA1 (patch-xen_Makefile) = 465388d80de414ca3bb84faefa0f52d817e423a6
 SHA1 (patch-xen_Rules.mk) = c743dc63f51fc280d529a7d9e08650292c171dac
 SHA1 (patch-xen_arch_x86_Kconfig) = df14bfa09b9a0008ca59d53c938d43a644822dd9
 SHA1 (patch-xen_arch_x86_Rules.mk) = 54392a7d719a21bc625a96b673056f88b96df97d
-SHA1 (patch-xen_arch_x86_boot_build32.mk) = b82c20de9b86ddaa9d05bbc1ff28f970eb78473c
+SHA1 (patch-xen_arch_x86_boot_build32.mk) = c7e57ee41ebf29ced32146945bddca7b482c6a49
 SHA1 (patch-xen_arch_x86_extable.c) = e439e6f3fe704d9b2894fc6b9e8f23f321a00f05
 SHA1 (patch-xen_arch_x86_mm_p2m.c) = 6e9b84dc8448eca9677f184e720bbfcb3c6d314e
 SHA1 (patch-xen_drivers_passthrough_x86_iommu.c) = 8b3a36a019490b1d125ea1f74274435382797da1

--- a/sysutils/xenkernel415/patches/patch-xen_arch_x86_boot_build32.mk
+++ b/sysutils/xenkernel415/patches/patch-xen_arch_x86_boot_build32.mk
@@ -1,9 +1,9 @@
-$NetBSD: patch-xen_arch_x86_boot_build32.mk,v 1.1 2021/04/18 12:31:26 bouyer Exp $
+$NetBSD: patch-xen_arch_x86_boot_build32.mk,v 1.1.6.1 2022/03/24 18:59:43 bsiegert Exp $
 linux's toolchain doesn't generate a .eh_frame section but NetBSD does.
 remove it.
 
---- xen/arch/x86/boot/build32.mk.orig	2018-04-17 19:21:31.000000000 +0200
-+++ xen/arch/x86/boot/build32.mk	2018-04-23 13:29:47.000000000 +0200
+--- xen/arch/x86/boot/build32.mk.orig	2022-01-31 10:42:09.000000000 +0100
++++ xen/arch/x86/boot/build32.mk	2022-03-03 14:12:56.486320239 +0100
 @@ -25,7 +25,7 @@
  				exit $$(expr $$idx + 1);; \
  			esac; \
@@ -11,5 +11,5 @@ remove it.
 -	$(OBJCOPY) -O binary -R .got.plt $< $@
 +	$(OBJCOPY) -O binary -R .got.plt -R .eh_frame $< $@
  
- %.lnk: %.o
+ %.lnk: %.o build32.lds
  	$(LD) $(LDFLAGS_DIRECT) -N -T build32.lds -o $@ $<

--- a/sysutils/xentools415/Makefile
+++ b/sysutils/xentools415/Makefile
@@ -1,11 +1,10 @@
-# $NetBSD: Makefile,v 1.8 2021/12/19 09:47:59 maya Exp $
+# $NetBSD: Makefile,v 1.8.2.1 2022/03/24 18:59:43 bsiegert Exp $
 #
-VERSION=	4.15.1
+VERSION=	4.15.2
 
 DIST_SUBDIR=		xen415
 DISTNAME=		xen-${VERSION}
 PKGNAME=		xentools415-${VERSION}
-PKGREVISION=		2
 CATEGORIES=		sysutils
 MASTER_SITES=		https://downloads.xenproject.org/release/xen/${VERSION}/
 
@@ -59,7 +58,7 @@ USE_TOOLS+=		pod2man gmake pkg-config makeinfo perl bash cmake gsed bison
 USE_LANGUAGES=		c c++
 
 GNU_CONFIGURE=		YES
-CONFIGURE_ARGS+=	--enable-rpath
+CONFIGURE_ARGS+=	--enable-rpath --disable-golang
 CONFIGURE_ARGS+=	--sysconfdir=${PKG_SYSCONFBASE}
 
 MAKE_ENV+=		PREFIX=${prefix:Q} WRKSRC=${WRKSRC}

--- a/sysutils/xentools415/distinfo
+++ b/sysutils/xentools415/distinfo
@@ -1,4 +1,4 @@
-$NetBSD: distinfo,v 1.6 2021/10/26 11:20:25 nia Exp $
+$NetBSD: distinfo,v 1.6.2.1 2022/03/24 18:59:43 bsiegert Exp $
 
 BLAKE2s (xen415/ipxe-988d2c13cdf0f0b4140685af35ced70ac5b3283c.tar.gz) = 67ded947316100f4f66fa61fe156baf1620db575450f4dc0dd8dcb323e57970b
 SHA512 (xen415/ipxe-988d2c13cdf0f0b4140685af35ced70ac5b3283c.tar.gz) = d888e0e653727ee9895fa866d8895e6d23a568b4e9e8439db4c4d790996700c60b0655e3a3129e599736ec2b4f7b987ce79d625ba208f06665fced8bddf94403
@@ -6,9 +6,9 @@ Size (xen415/ipxe-988d2c13cdf0f0b4140685af35ced70ac5b3283c.tar.gz) = 3937560 byt
 BLAKE2s (xen415/seabios-1.14.0.tar.gz) = c34103500436ad4726f15f2ed181205736143fc41af5c4b32a7055cd021edc1d
 SHA512 (xen415/seabios-1.14.0.tar.gz) = f282175484c99488f4349ff4d3af9a74d96df3e8dcbe679fcea5b8b559f95f600756939d99d6e61dabace206d3d9ccefdc8fa2bc7709d34d6a0dc085d6c79238
 Size (xen415/seabios-1.14.0.tar.gz) = 628981 bytes
-BLAKE2s (xen415/xen-4.15.1.tar.gz) = 87499f2cbe2a81fd92e0d4803adbe8681b9a26348aa8e069890b6ea441731986
-SHA512 (xen415/xen-4.15.1.tar.gz) = 8d3cbdf708f46477e32ee7cbd16a490c82efa855cecd84ee712b8680df4d69c987ba9ab00ff3851f627b98a8ebbc5dab71f92f142ed958ee2bc538bc792cd4b9
-Size (xen415/xen-4.15.1.tar.gz) = 40800852 bytes
+BLAKE2s (xen415/xen-4.15.2.tar.gz) = f6e3d354a144c9ff49a198ebcafbd5e8a4414690d5672b3e2ed394c461ab8ab0
+SHA512 (xen415/xen-4.15.2.tar.gz) = 1cbf988fa8ed38b7ad724978958092ca0e5506e38c709c7d1af196fb8cb8ec0197a79867782761ef230b268624b3d7a0d5d0cd186f37d25f495085c71bf70d54
+Size (xen415/xen-4.15.2.tar.gz) = 40773378 bytes
 SHA1 (patch-.._seabios-rel-1.14.0_src_string.c) = 87e2e28fe47c196e74fea073c7e7f7d03990fbe3
 SHA1 (patch-Config.mk) = d108a1743b5b5313d3ea957b02a005b49f5b3bf6
 SHA1 (patch-Makefile) = 6c580cbea532d08a38cf5e54228bd0210a98da21


### PR DESCRIPTION
sysutils/xenkernel415: security fix
sysutils/xentools415: security fix

Revisions pulled up:
- sysutils/xenkernel415/Makefile                                1.4
- sysutils/xenkernel415/distinfo                                1.5
- sysutils/xenkernel415/patches/patch-xen_arch_x86_boot_build32.mk 1.2
- sysutils/xentools415/Makefile                                 1.10
- sysutils/xentools415/distinfo                                 1.7

---
   Module Name:	pkgsrc
   Committed By:	bouyer
   Date:		Fri Mar  4 17:54:08 UTC 2022

   Modified Files:
   	pkgsrc/sysutils/xenkernel415: Makefile distinfo
   	pkgsrc/sysutils/xenkernel415/patches:
   	    patch-xen_arch_x86_boot_build32.mk
   	pkgsrc/sysutils/xentools415: Makefile distinfo

   Log Message:
   Update xenkernel415 and xentools415 to 4.15.2
   Changes from 4.15.1 are bugfixes, some performance improvements and
   some security hardening. It also includes all fixes for XSA up to 395.