### PR TITLE
links: update to 2.28.

### DIFF
--- a/www/links/Makefile.common
+++ b/www/links/Makefile.common
@@ -1,9 +1,9 @@
-# $NetBSD: Makefile.common,v 1.77 2021/06/29 15:13:23 fcambus Exp $
+# $NetBSD: Makefile.common,v 1.81 2022/11/02 18:10:03 fcambus Exp $
 #
 # used by www/links/Makefile
 # used by www/links-gui/Makefile
 
-DISTNAME=	links-2.23
+DISTNAME=	links-2.28
 CATEGORIES=	www
 MASTER_SITES=	http://links.twibright.com/download/
 EXTRACT_SUFX=	.tar.bz2

--- a/www/links/distinfo
+++ b/www/links/distinfo
@@ -1,7 +1,7 @@
-$NetBSD: distinfo,v 1.80 2021/10/26 11:29:37 nia Exp $
+$NetBSD: distinfo,v 1.84 2022/11/02 18:10:03 fcambus Exp $
 
-BLAKE2s (links-2.23.tar.bz2) = 7f5dad45d1bed86f397d1f20a178f9f547c718172e11e4a6a420f2c42d6478d6
-SHA512 (links-2.23.tar.bz2) = 3c233dab2e7e5ca72f582c5af9c5799b3d6c1a5a64d4e9e0209f78f347a245dc760c2340f71839fd42e1c9f358599b8baa12aa024938f2ab1b6424c8fb0b9a7d
-Size (links-2.23.tar.bz2) = 6521143 bytes
-SHA1 (patch-configure) = 047d48d898f674f5f0b18c700e6296fe180380e2
-SHA1 (patch-x.c) = 3aff5484e803495febf417bb5c2b9e3d79a265d4
+BLAKE2s (links-2.28.tar.bz2) = 1e10f326bb280a2f941f3579df4eb656326c8f52bf3386529e89100dd0e829a0
+SHA512 (links-2.28.tar.bz2) = 090bc770f78f8b57358ac0c6f31ad12f3d5f4eb9bbf74913ac8fa254e5ed63ec289c8a7990879983ace7427e20fb2de1271820f025b630c5a0ca599cf697b754
+Size (links-2.28.tar.bz2) = 6512800 bytes
+SHA1 (patch-configure) = 38044f43a6985c50dd0275e9927dcc98a91dcc47
+SHA1 (patch-x.c) = 18521103f0d585416cc27804e825d764c7df61ee


### PR DESCRIPTION
=== RELEASE 2.28 ===

Sat Sep 17 21:54:44 CEST 2022 mikulas:

- Disable cache when following redirects from consent.google.com

Sat Sep 10 16:05:02 CEST 2022 mikulas:

- On Windows, change the default directory to the "Downloads" directory, so that downloaded files are placed there

Sat Sep 10 15:31:20 CEST 2022 mikulas:

- Compile the 32-bit Windows version without SSE2 instructions

Tue May 31 21:07:51 CEST 2022 mikulas:

- Fix a display glitch on framebuffer, if the user doesn't have mouse and if he presses F5, F6, F7 or F8